### PR TITLE
Fix issue #3; Remove type declaration of make_pair

### DIFF
--- a/seql_classify.cpp
+++ b/seql_classify.cpp
@@ -103,8 +103,8 @@ private:
   		   	if (id >= 0) {
 				if (userule) {
 					//cout << "\nnew rule: " << item;
-					rules.insert (std::make_pair <std::string, double> (item, alpha[id]));
-					rules_and_ids.insert (std::make_pair <std::string, int> (item, id));
+					rules.insert (std::make_pair(item, alpha[id]));
+					rules_and_ids.insert (std::make_pair(item, id));
 				}
 			  result.push_back (id);
 			}
@@ -226,8 +226,8 @@ public:
        	if (id == -2) continue;
        	if (id >= 0) {
 			if (userule) {
-		   		rules.insert (std::make_pair <std::string, double> (doc[i].key(), alpha[id]));
-				rules_and_ids.insert (std::make_pair <std::string, int> (doc[i].key(), id));
+		   		rules.insert (std::make_pair(doc[i].key(), alpha[id]));
+				rules_and_ids.insert (std::make_pair(doc[i].key(), id));
 			}
 		 	result.push_back (id);
        	}
@@ -255,7 +255,7 @@ public:
 
     for (std::map <std::string, double>::iterator it = rules.begin();
 	 it != rules.end(); ++it)
-      tmp.push_back (std::make_pair <std::string, double> (it->first,  it->second));
+      tmp.push_back (std::make_pair(it->first,  it->second));
 
     std::sort (tmp.begin(), tmp.end(), pair_2nd_cmp<std::string, double>());
 	  os << "\nrule: " << bias << " __DFAULT__" << std::endl;

--- a/seql_classify_tune_threshold_min_errors.cpp
+++ b/seql_classify_tune_threshold_min_errors.cpp
@@ -97,7 +97,7 @@ private:
 	  		   	if (id >= 0) {
 				  if (userule) {
 					//cout << "\nnew rule: " << item;
-					rules.insert (std::make_pair <std::string, double> (item, alpha[id]));
+					rules.insert (std::make_pair (item, alpha[id]));
 				  }
 				  result.push_back (id);
 				}
@@ -178,7 +178,7 @@ public:
 	       if (id >= 0) {
 			 if (userule) {
 			  	//cout << "\nnew rule: " << doc[i].key();
-			   	rules.insert (std::make_pair <std::string, double> (doc[i].key(), alpha[id]));
+			   	rules.insert (std::make_pair (doc[i].key(), alpha[id]));
 			 }
 			 result.push_back (id);
 	       }
@@ -199,7 +199,7 @@ public:
 	    std::vector <std::pair <std::string, double> > tmp;
 
 	    for (std::map <std::string, double>::iterator it = rules.begin(); it != rules.end(); ++it)
-	    	tmp.push_back (std::make_pair <std::string, double> (it->first,  it->second));
+	    	tmp.push_back (std::make_pair (it->first,  it->second));
 
 	    std::sort (tmp.begin(), tmp.end(), pair_2nd_cmp<std::string, double>());
 

--- a/seql_mkmodel.cpp
+++ b/seql_mkmodel.cpp
@@ -114,7 +114,7 @@ int main (int argc, char **argv)
     double a = it->second / alpha_sum;
     l2_norm += 	pow(it->second, 2);
 
-    ary2.push_back (std::make_pair <const char*, double>(it->first.c_str(), a));
+    ary2.push_back (std::make_pair(it->first.c_str(), a));
     ary.push_back  ((Darts::DoubleArray::key_type *)it->first.c_str());
     alpha.push_back (a);
   }


### PR DESCRIPTION
This pull request should fix the compiler issue mentioned in issue #3.

The make_pair function is used to automatically deduce the type. Given that the type is explicitly mentioned it will lead to the error as the deduced and explicitly stated type isn't the same.

With these changes, compilation works for me on Linux with GCC 10.1.0 and GCC 7.5. However, could not test on a windows or apple machine

